### PR TITLE
fix: cached images rebuilding on scroll

### DIFF
--- a/lib/features/home/views/home_page.dart
+++ b/lib/features/home/views/home_page.dart
@@ -32,6 +32,7 @@ class HomePage extends ConsumerWidget {
     final headers = buildHeaders(context);
 
     return CustomScrollView(
+      cacheExtent: 9999, // Increase cache size to avoid rebuilding image.
       slivers: [
         const SliverAppBar(),
         SliverList(
@@ -54,8 +55,6 @@ class HomePage extends ConsumerWidget {
                 error: (error, stackTrace) => Text(error.toString()),
                 data: (data) => CachedNetworkImage(
                   imageUrl: data[index - headers.length],
-                  placeholder: (context, url) =>
-                      const CircularProgressIndicator.adaptive(),
                 ),
               );
             },

--- a/lib/widgets/vjchoir_app_bar.dart
+++ b/lib/widgets/vjchoir_app_bar.dart
@@ -9,6 +9,7 @@ class VjchoirAppBar extends StatelessWidget with PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
+      centerTitle: true,
       title: Assets.logos.vjchoir
           .svg(fit: BoxFit.scaleDown, height: kToolbarHeight),
     );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
Fixes bad UX when having cached network images in ScrollView.
Center Appbar logo on android.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
